### PR TITLE
Finished, but still one curious warning near the end.

### DIFF
--- a/objc-xcode-warnings-errors/FISAppDelegate.m
+++ b/objc-xcode-warnings-errors/FISAppDelegate.m
@@ -9,40 +9,41 @@
     
     NSString *unused = @"This variable generates a warning because it is unused.";
     
-//    NSLog(@"%@", unused);
+    NSLog(@"%@", unused);
     
-//    NSInteger *i = 0;
-//    NSLog(@"i: %li", i);
+    NSInteger i = 12;
+    NSLog(@"i: %li", i);
     
-//    NSInteger x = i + 1;
-//    NSLog(@"x: %li", x);
+    NSInteger x = i + 1;
+    NSLog(@"x: %li", x);
     
     NSLog(@"Anything after the return statement will not get executed.");
     
+    NSLog(@"Take note that this line doesn't print to the console.");
+    
+    NSString *message = @"Even though they don't belong here, the compiler won't actually complain about string literals or primitives defined outside of a method body (which is held by  curly braces {...} ), but...";
+    
+    NSInteger j = 0;
+    BOOL itIsKnownKhaleesi = YES;
+    
+    NSLog(@"...any statements containing function calls, operations, or method calls will produce errors.");
+    
+    
+    NSLog(@"%@", message);
+    
+    
+    j++;
+    
+    
+    itIsKnownKhaleesi = NO;
+    
+    //I think that xcodes recommended fix for this line is appropriate in this case, but not entirely sure, will leave as is for now.
+    NSString *notLocal = [NSString stringWithString:@"Which means the variables above, while permitted, can't be used in the way that you intend."];
+    
     return YES; // this line ends the method
     
-    NSLog(@"Take note that this line doesn't print to the console.");
 }
 
-//NSString *message = @"Even though they don't belong here, the compiler won't actually complain about string literals or primitives defined outside of a method body (which is held by  curly braces {...} ), but...";
 
-//NSInteger j = 0;
-//BOOL itIsKnownKhaleesi = YES;
-
-//NSLog(@"...any statements containing function calls, operations, or method calls will produce errors.");
-
-
-
-
-//NSLog(@"%@", message);
-
-
-
-//j++;
-
-//itIsKnownKhaleesi = NO;
-
-
-//NSString *notLocal = [NSString stringWithString:@"Which means the variables above, while permitted, can't be used in the way that you intend."];
 
 @end


### PR DESCRIPTION
the warning didn't have any apparent effect at runtime. the pre-compiler was complaining about the stringWithString method on NSString being redundant when using a literal string, which does make some sense. I left it as is, as I was unsure. Thanks!
